### PR TITLE
Add keypair resource to enable access to ec2 instance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ OALLexer.tokens
 oap-server/oal-grammar/**/gen/
 aws/.terraform/
 aws/.terraform.lock.hcl
+aws/terraform.tfstate
+aws/terraform.tfstate.backup
 
 # This serves as a template but will ONLY be updated when building a source release tar,
 # so we don't track future updates of this file.

--- a/aws/ec2.tf
+++ b/aws/ec2.tf
@@ -13,13 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+provider "aws" {
+    region = var.region
+}
+
 resource "aws_instance" "skywalking" {
-  ami = "ami-026ebd4cfe2c043b2"
-  instance_type = "t2.medium"
+  ami = var.ami
+  instance_type = var.instance_type
   tags = {
     Name = "skywalking-terraform"
-    Description = "Skywalking installed on RHEL"
+    Description = "Installing and configuring Skywalking on AWS"
   }
+  key_name = aws_key_pair.ssh-user.id
   vpc_security_group_ids = [ aws_security_group.ssh-access.id ]
 }
 
@@ -41,6 +46,6 @@ resource "aws_security_group" "ssh-access" {
   ]
 }
 
-output publicip {
-  value = aws_instance.skywalking.public_ip
+resource "aws_key_pair" "ssh-user" {
+    public_key = file(var.public_key_path)
 }

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -13,6 +13,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-provider "aws" {
-    region = "us-east-1"
+variable "region" {
+  type        = string
+  description = "Physical location for clustered data centers."
+  default     = "us-east-1"
+}
+
+variable "ami" {
+  type        = string
+  description = "Amazon Machine Image"
+  default     = "ami-026ebd4cfe2c043b2"
+}
+
+variable "instance_type" {
+  type        = string
+  description = "CPU, memory, storage and networking capacity"
+  default     = "t2.medium"
+}
+
+variable "public_key_path" {
+  type        = string
+  description = "Path to the public key file"
+  default     = "~/.ssh/skywalking-terraform.pub"
 }


### PR DESCRIPTION
This pull request aims to enhance the provisioning process of an EC2 instance by introducing customizable variables. With this PR, users can now define their preferred configurations while creating an EC2 instance. Specifically, it ensures that users with a public key located at `~/.ssh/skywalking-terraform.pub` can successfully create an EC2 instance.