### PR TITLE
Add option to control key pair retention

### DIFF
--- a/aws/ec2.tf
+++ b/aws/ec2.tf
@@ -24,7 +24,7 @@ resource "aws_instance" "skywalking" {
     Name = "skywalking-terraform"
     Description = "Installing and configuring Skywalking on AWS"
   }
-  key_name = aws_key_pair.ssh-user.id
+  key_name = var.keep_key_pair ? aws_key_pair.ssh-user.id : null
   vpc_security_group_ids = [ aws_security_group.ssh-access.id ]
 }
 

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -36,3 +36,9 @@ variable "public_key_path" {
   description = "Path to the public key file"
   default     = "~/.ssh/skywalking-terraform.pub"
 }
+
+variable "keep_key_pair" {
+  description = "Controls whether to keep the key pair or not"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
Introduce the `keep_key_pair` variable to allow users to control whether to keep or delete the key pair. When set to true, the key pair is created and retained for future use. When set to false, the key pair is not created, providing flexibility for new installations or specific use cases.