### PR TITLE
Add support for extra tags on all resources

### DIFF
--- a/aws/ec2.tf
+++ b/aws/ec2.tf
@@ -20,10 +20,13 @@ provider "aws" {
 resource "aws_instance" "skywalking" {
   ami = var.ami
   instance_type = var.instance_type
-  tags = {
-    Name = "skywalking-terraform"
-    Description = "Installing and configuring Skywalking on AWS"
-  }
+  tags = merge(
+    {
+      Name = "skywalking-terraform"
+      Description = "Installing and configuring Skywalking on AWS"
+    },
+    var.extra_tags
+  )
   key_name = aws_key_pair.ssh-user.id
   vpc_security_group_ids = [ aws_security_group.ssh-access.id ]
 }
@@ -44,8 +47,10 @@ resource "aws_security_group" "ssh-access" {
       self            = false
     }
   ]
+  tags = var.extra_tags
 }
 
 resource "aws_key_pair" "ssh-user" {
     public_key = file(var.public_key_path)
+    tags = var.extra_tags
 }

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -36,3 +36,9 @@ variable "public_key_path" {
   description = "Path to the public key file"
   default     = "~/.ssh/skywalking-terraform.pub"
 }
+
+variable "extra_tags" {
+  description = "Additional tags to be added to all resources"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
This change introduces the ability to include extra tags on all resources created by Terraform. As @kezhenxu94 suggested - this enhancement enables compliance with enterprise-specific AWS tagging requirements and ensures a smooth resource creation process.