### PR TITLE
Add Ansible role for installing skywalking

### DIFF
--- a/ansible/playbooks/install-skywalking.yml
+++ b/ansible/playbooks/install-skywalking.yml
@@ -14,8 +14,15 @@
 # limitations under the License.
 
 ---
-- name: Download and configure Apache SkyWalking APM
-  hosts: skywalking_server
+- name: Download and configure Apache SkyWalking APM OAP Service
+  hosts: skywalking-oap
+  gather_facts: false
+
+  roles:
+    - skywalking
+
+- name: Download and configure Apache SkyWalking APM UI Service
+  hosts: skywalking-ui
   gather_facts: false
 
   roles:

--- a/ansible/playbooks/install-skywalking.yml
+++ b/ansible/playbooks/install-skywalking.yml
@@ -13,12 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-[defaults]
-roles_path = roles/
-inventory = inventory/
-timeout = 60
+---
+- name: Download and configure Apache SkyWalking APM
+  hosts: skywalking_server
+  gather_facts: false
 
-[privilege_escalation]
-become = yes
-become_method = sudo
-become_flags = 'su -c'
+  roles:
+    - skywalking

--- a/ansible/roles/install-java/tasks/main.yml
+++ b/ansible/roles/install-java/tasks/main.yml
@@ -14,22 +14,14 @@
 # limitations under the License.
 
 ---
-- name: Install Java
-  hosts: skywalking-oap
-  gather_facts: true
-  roles:
-    - install-java
+- name: Install Java 11 on RHEL-based systems
+  package:
+    name: java-11-openjdk
+    state: present
+  when: ansible_distribution == 'RedHat' or ansible_distribution == 'CentOS' or ansible_distribution == 'Fedora'
 
-- name: Download and configure Apache SkyWalking APM OAP Service
-  hosts: skywalking-oap
-  gather_facts: false
-
-  roles:
-    - skywalking
-
-- name: Download and configure Apache SkyWalking APM UI Service
-  hosts: skywalking-ui
-  gather_facts: false
-
-  roles:
-    - skywalking
+- name: Install Java 11 on Ubuntu systems
+  package:
+    name: openjdk-11-jdk
+    state: present
+  when: ansible_distribution == 'Ubuntu'

--- a/ansible/roles/skywalking/tasks/main.yml
+++ b/ansible/roles/skywalking/tasks/main.yml
@@ -51,6 +51,14 @@
     mode: "0660"
   when: inventory_hostname in groups['skywalking-oap']
 
+- name: Generate script to stop oap service
+  template:
+    src: oap-service-stop.sh.j2
+    dest: /usr/local/skywalking/bin/oapServiceStop.sh
+    owner: root
+    mode: "0755"
+  when: inventory_hostname in groups['skywalking-oap']
+
 - name: Generate systemd unit file for webui service
   template:
     src: skywalking-ui.service.j2

--- a/ansible/roles/skywalking/tasks/main.yml
+++ b/ansible/roles/skywalking/tasks/main.yml
@@ -38,29 +38,51 @@
 
 - name: Extract tar file
   unarchive:
-    src: "/usr/local/skywalking/apache-skywalking-apm-9.4.0.tar.gz"
+    src: "/usr/local/skywalking/apache-skywalking-apm-{{ skywalking_version }}.tar.gz"
     dest: "/usr/local/skywalking"
     remote_src: yes
     extra_opts: [--strip-components=1]
 
-- name: Generate systemd unit file
+- name: Generate systemd unit file for oap service
   template:
-    src: skywalking.service.j2
-    dest: /usr/lib/systemd/system/skywalking.service
+    src: skywalking-oap.service.j2
+    dest: /usr/lib/systemd/system/skywalking-oap.service
     owner: root
     mode: "0660"
+  when: inventory_hostname in groups['skywalking-oap']
+
+- name: Generate systemd unit file for webui service
+  template:
+    src: skywalking-ui.service.j2
+    dest: /usr/lib/systemd/system/skywalking-ui.service
+    owner: root
+    mode: "0660"
+  when: inventory_hostname in groups['skywalking-ui']
 
 - name: Reload systemd
   systemd:
     daemon_reload: yes
 
-- name: Link and enable skywalking service
+- name: Link and enable skywalking-oap service
   systemd:
-    name: skywalking
+    name: skywalking-oap
     enabled: yes
+  when: inventory_hostname in groups['skywalking-oap']
 
-- name: Start Apache SkyWalking service
+- name: Link and enable skywalking-ui service
   systemd:
-    name: skywalking
-    state: started
+    name: skywalking-ui
     enabled: yes
+  when: inventory_hostname in groups['skywalking-ui']
+
+- name: Start SkyWalking-OAP service
+  systemd:
+    name: skywalking-oap
+    state: started
+  when: inventory_hostname in groups['skywalking-oap']
+
+- name: Start SkyWalking-UI service
+  systemd:
+    name: skywalking-ui
+    state: started
+  when: inventory_hostname in groups['skywalking-ui']

--- a/ansible/roles/skywalking/tasks/main.yml
+++ b/ansible/roles/skywalking/tasks/main.yml
@@ -1,0 +1,66 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+- name: Create skywalking directory
+  file:
+    path: /usr/local/skywalking
+    state: directory
+    mode: "0755"
+    owner: root
+    group: root
+
+- name: Set ownership and permissions for skywalking directory
+  file:
+    path: /usr/local/skywalking
+    state: directory
+    recurse: yes
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Download Apache SkyWalking tar file
+  get_url:
+    url: "https://dlcdn.apache.org/skywalking/{{ skywalking_version }}/apache-skywalking-apm-{{ skywalking_version }}.tar.gz"
+    dest: "/usr/local/skywalking/apache-skywalking-apm-{{ skywalking_version }}.tar.gz"
+
+- name: Extract tar file
+  unarchive:
+    src: "/usr/local/skywalking/apache-skywalking-apm-9.4.0.tar.gz"
+    dest: "/usr/local/skywalking"
+    remote_src: yes
+    extra_opts: [--strip-components=1]
+
+- name: Generate systemd unit file
+  template:
+    src: skywalking.service.j2
+    dest: /usr/lib/systemd/system/skywalking.service
+    owner: root
+    mode: "0660"
+
+- name: Reload systemd
+  systemd:
+    daemon_reload: yes
+
+- name: Link and enable skywalking service
+  systemd:
+    name: skywalking
+    enabled: yes
+
+- name: Start Apache SkyWalking service
+  systemd:
+    name: skywalking
+    state: started
+    enabled: yes

--- a/ansible/roles/skywalking/templates/oap-service-stop.sh.j2
+++ b/ansible/roles/skywalking/templates/oap-service-stop.sh.j2
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.
@@ -13,23 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
----
-- name: Install Java
-  hosts: skywalking-oap
-  gather_facts: true
-  roles:
-    - install-java
+# Send SIGTERM to the main process
+/bin/kill -SIGTERM $MAINPID
 
-- name: Download and configure Apache SkyWalking APM OAP Service
-  hosts: skywalking-oap
-  gather_facts: false
-
-  roles:
-    - skywalking
-
-- name: Download and configure Apache SkyWalking APM UI Service
-  hosts: skywalking-ui
-  gather_facts: false
-
-  roles:
-    - skywalking
+# Find all child processes and send SIGTERM to each of them
+for child_pid in $(pgrep -P $MAINPID); do
+    /bin/kill -SIGTERM $child_pid
+done

--- a/ansible/roles/skywalking/templates/skywalking-oap.service.j2
+++ b/ansible/roles/skywalking/templates/skywalking-oap.service.j2
@@ -14,14 +14,14 @@
 # limitations under the License.
 
 [Unit]
-Description=Apache SkyWalking APM
+Description=Apache SkyWalking OAP Service
 After=network.target
 
 [Service]
-User=root
-WorkingDirectory=/usr/local/skywalking
-ExecStart=/usr/local/skywalking/bin/startup.sh
-ExecStop=/usr/local/skywalking/bin/startup.sh
+Type=simple
+ExecStartPre=/usr/local/skywalking/bin/oapServiceInit.sh
+ExecStart=/usr/local/skywalking/bin/oapService.sh
+ExecStop=/bin/kill -SIGTERM $MAINPID
 Restart=always
 
 [Install]

--- a/ansible/roles/skywalking/templates/skywalking-oap.service.j2
+++ b/ansible/roles/skywalking/templates/skywalking-oap.service.j2
@@ -20,8 +20,10 @@ After=network.target
 [Service]
 Type=simple
 ExecStartPre=/usr/local/skywalking/bin/oapServiceInit.sh
+TimeoutStartSec=600
 ExecStart=/usr/local/skywalking/bin/oapService.sh
-ExecStop=/bin/kill -SIGTERM $MAINPID
+TimeoutSec=300
+ExecStop=/bin/bash -c '/usr/local/skywalking/bin/oapServiceStop.sh'
 Restart=always
 
 [Install]

--- a/ansible/roles/skywalking/templates/skywalking-ui.service.j2
+++ b/ansible/roles/skywalking/templates/skywalking-ui.service.j2
@@ -20,7 +20,7 @@ After=network.target
 [Service]
 Type=simple
 ExecStart=/usr/local/skywalking/bin/webappService.sh
-ExecStop=/bin/kill -SIGTERM \$MAINPID
+ExecStop=/bin/kill -SIGTERM $MAINPID
 Restart=always
 
 [Install]

--- a/ansible/roles/skywalking/templates/skywalking-ui.service.j2
+++ b/ansible/roles/skywalking/templates/skywalking-ui.service.j2
@@ -13,5 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
----
-skywalking_version: "9.5.0"
+[Unit]
+Description=Apache SkyWalking UI Service
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/skywalking/bin/webappService.sh
+ExecStop=/bin/kill -SIGTERM \$MAINPID
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/skywalking/templates/skywalking.service.j2
+++ b/ansible/roles/skywalking/templates/skywalking.service.j2
@@ -13,12 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-[defaults]
-roles_path = roles/
-inventory = inventory/
-timeout = 60
+[Unit]
+Description=Apache SkyWalking APM
+After=network.target
 
-[privilege_escalation]
-become = yes
-become_method = sudo
-become_flags = 'su -c'
+[Service]
+User=root
+WorkingDirectory=/usr/local/skywalking
+ExecStart=/usr/local/skywalking/bin/startup.sh
+ExecStop=/usr/local/skywalking/bin/startup.sh
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/skywalking/vars/main.yml
+++ b/ansible/roles/skywalking/vars/main.yml
@@ -13,12 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-[defaults]
-roles_path = roles/
-inventory = inventory/
-timeout = 60
-
-[privilege_escalation]
-become = yes
-become_method = sudo
-become_flags = 'su -c'
+---
+skywalking_version: "9.4.0"


### PR DESCRIPTION
This commit adds an Ansible role for managing the skywalking service. The role includes tasks for installing dependencies, downloading the skywalking binary, configuring the service, and starting it. The role is designed to streamline the deployment and management of the skywalking service in an Ansible playbook.
