### PR TITLE
Add option to create multiple OAP and UI servers on AWS

### DIFF
--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -13,6 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+variable "oap_instance_count" {
+  type    = number
+  default = 1
+}
+
+variable "ui_instance_count" {
+  type    = number
+  default = 1
+}
+
 variable "region" {
   type        = string
   description = "Physical location for clustered data centers."


### PR DESCRIPTION
With this enhancement, users can easily scale the number of OAP and UI servers as per their requirements, and the corresponding Ansible inventory files will be created with the correct IP addresses for seamless integration into Ansible workflows.

In the future, we might look at a dynamic inventory file.