### PR TITLE
Need to install java on all machines (OAP and UI)

### DIFF
--- a/ansible/playbooks/install-skywalking.yml
+++ b/ansible/playbooks/install-skywalking.yml
@@ -15,7 +15,7 @@
 
 ---
 - name: Install Java
-  hosts: skywalking-oap
+  hosts: all
   gather_facts: true
   roles:
     - install-java


### PR DESCRIPTION
Java installation is essential for both WebUI and OAP, and therefore, we must install Java on both systems.