### PR TITLE
Implement env variables support for WebUI systemd unit file

### DIFF
--- a/ansible/roles/skywalking/tasks/main.yml
+++ b/ansible/roles/skywalking/tasks/main.yml
@@ -73,6 +73,13 @@
     mode: "0660"
   when: inventory_hostname in groups['skywalking-ui']
 
+- name: Registration of OAP Server address within WebUI environment file
+  ansible.builtin.lineinfile:
+    path: "{{ env_file }}"
+    line: "{{ item.key }}={{ item.value }}"
+    create: yes
+  loop: "{{ sw_ui_env_vars|dict2items }}"
+
 - name: Reload systemd
   systemd:
     daemon_reload: yes

--- a/ansible/roles/skywalking/templates/skywalking-ui.service.j2
+++ b/ansible/roles/skywalking/templates/skywalking-ui.service.j2
@@ -14,14 +14,17 @@
 # limitations under the License.
 
 [Unit]
-Description=Apache SkyWalking UI Service
+Description=Apache SkyWalking WebUI Service
 After=network.target
 
 [Service]
 Type=simple
+EnvironmentFile=/usr/local/skywalking/webapp/webui_env
 ExecStart=/usr/local/skywalking/bin/webappService.sh
-ExecStop=/bin/kill -SIGTERM $MAINPID
-Restart=always
+TimeoutSec=300
+KillMode=process
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target

--- a/ansible/roles/skywalking/vars/main.yml
+++ b/ansible/roles/skywalking/vars/main.yml
@@ -15,3 +15,12 @@
 
 ---
 skywalking_version: "9.5.0"
+sw_ui_server_port: "8080"
+sw_oap_server_port: "12800"
+sw_zipkin_address: "9412"
+
+sw_ui_env_vars:
+  SW_SERVER_PORT: "{{ sw_ui_server_port }}"
+  SW_OAP_ADDRESS: "{% for host in groups['skywalking-oap'] %}http://{{ hostvars[host].ansible_host }}:{{ sw_oap_server_port }}{% if not loop.last %},{% endif %}{% endfor %}}"
+  SW_ZIPKIN_ADDEESS: "{% for host in groups['skywalking-oap'] %}http://{{ hostvars[host].ansible_host }}:{{ sw_zipkin_address }}{% if not loop.last %},{% endif %}{% endfor %}}"
+env_file: /usr/local/skywalking/webapp/sw_ui_env_file


### PR DESCRIPTION
This commit introduces the use of environment variables for the systemd unit file of our service. The following changes were made:

1. Defined environment variables in an Ansible role, under defaults/main.yml. This includes the SkyWalking version, SkyWalking UI server port, and SkyWalking OAP server port.
2. Created an environment file that includes these variables. The path to this environment file is also defined in the Ansible defaults of the role.
3. Updated the systemd unit file to use the environment file. This ensures the service process has access to the correct environment variables.

These changes will enable better configurability of our service and reduce the likelihood of hardcoding values in our scripts and systemd unit files.
