### PR TITLE
Change OAP and WebUI server unit files to run as non-root user

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -21,4 +21,3 @@ timeout = 60
 [privilege_escalation]
 become = yes
 become_method = sudo
-become_flags = 'su -c'

--- a/ansible/playbooks/install-skywalking.yml
+++ b/ansible/playbooks/install-skywalking.yml
@@ -21,6 +21,7 @@
     become: true
     user:
       name: skywalking
+      group: skywalking
       state: present
 
 - name: Install Java

--- a/ansible/playbooks/install-skywalking.yml
+++ b/ansible/playbooks/install-skywalking.yml
@@ -14,6 +14,15 @@
 # limitations under the License.
 
 ---
+- hosts: all
+  gather_facts: false
+  tasks:
+  - name: Create user skywalking
+    become: true
+    user:
+      name: skywalking
+      state: present
+
 - name: Install Java
   hosts: all
   gather_facts: true
@@ -23,13 +32,11 @@
 - name: Download and configure Apache SkyWalking APM OAP Service
   hosts: skywalking_oap
   gather_facts: false
-
   roles:
     - skywalking
 
 - name: Download and configure Apache SkyWalking APM UI Service
   hosts: skywalking_ui
   gather_facts: false
-
   roles:
     - skywalking

--- a/ansible/roles/skywalking/tasks/main.yml
+++ b/ansible/roles/skywalking/tasks/main.yml
@@ -14,21 +14,13 @@
 # limitations under the License.
 
 ---
-- name: Create skywalking directory
-  file:
-    path: /usr/local/skywalking
-    state: directory
-    mode: "0755"
-    owner: root
-    group: root
-
-- name: Set ownership and permissions for skywalking directory
+- name: Create and set permissions for skywalking directory
   file:
     path: /usr/local/skywalking
     state: directory
     recurse: yes
-    owner: root
-    group: root
+    owner: skywalking
+    group: skywalking
     mode: "0755"
 
 - name: Download Apache SkyWalking tar file
@@ -42,6 +34,13 @@
     dest: "/usr/local/skywalking"
     remote_src: yes
     extra_opts: [--strip-components=1]
+
+- name: Set ownership for extracted files
+  ansible.builtin.file:
+    path: /usr/local/skywalking
+    owner: skywalking
+    group: skywalking
+    recurse: yes
 
 - name: Check hostgroup size
   set_fact:

--- a/ansible/roles/skywalking/templates/skywalking-oap.service.j2
+++ b/ansible/roles/skywalking/templates/skywalking-oap.service.j2
@@ -19,6 +19,8 @@ After=network.target
 
 [Service]
 Type=simple
+User=skywalking
+Group=skywalking
 ExecStart=/usr/local/skywalking/bin/oapService.sh
 TimeoutSec=300
 KillMode=process

--- a/ansible/roles/skywalking/templates/skywalking-ui.service.j2
+++ b/ansible/roles/skywalking/templates/skywalking-ui.service.j2
@@ -20,6 +20,8 @@ After=network.target
 [Service]
 Type=simple
 EnvironmentFile=/usr/local/skywalking/webapp/sw_ui_env_file
+User=skywalking
+Group=skywalking
 ExecStart=/usr/local/skywalking/bin/webappService.sh
 TimeoutSec=300
 KillMode=process


### PR DESCRIPTION
To enhance the security of the application, we have ensured that all the operations are executed with non-root user permissions. The ownership of the directory and its content is set to the 'skywalking' user, effectively allowing SkyWalking to run as a non-root user.

These changes minimize potential security risks and align with the best practices for running applications in production environments.
