### PR TITLE
Optimize SkyWalking UI Environment File Setup~

### DIFF
--- a/ansible/roles/skywalking/tasks/main.yml
+++ b/ansible/roles/skywalking/tasks/main.yml
@@ -79,6 +79,7 @@
     line: "{{ item.key }}={{ item.value }}"
     create: yes
   loop: "{{ sw_ui_env_vars | dict2items }}"
+  when: inventory_hostname in groups['skywalking_ui']
 
 - name: Reload systemd
   systemd:


### PR DESCRIPTION
The task now loops over the sw_ui_env_vars dictionary and adds each item to the environment file only when the current inventory_hostname is in the skywalking_ui group. This efficient approach skips unnecessary operations (on OAP server) and ensures that only relevant entries are added to the environment file, specifically tailoring it to the SkyWalking UI group.