### PR TITLE
Add some basic doc

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -16,11 +16,12 @@
 #
 
 github:
-  description: Terraform modules for Apache SkyWalking
+  description: Terraform modules and Ansible playbook for Apache SkyWalking
   homepage: https://skywalking.apache.org/
   labels:
     - skywalking
     - terraform
+    - ansible
   enabled_merge_buttons:
     squash:  true
     merge:   false

--- a/LICENSE
+++ b/LICENSE
@@ -207,21 +207,3 @@ The Apache SkyWalking project contains subcomponents with separate copyright
 notices and license terms. Your use of the source code for the these
 subcomponents is subject to the terms and conditions of the following
 licenses.
-
-========================================================================
-Apache 2.0 licenses
-========================================================================
-
-The following components are provided under the Apache License. See project link for details.
-The text of each license is the standard Apache 2.0 license.
-
-   proto files from cncf/udpa: https://github.com/cncf/udpa Apache 2.0
-   proto files from envoyproxy/data-plane-api: https://github.com/envoyproxy/data-plane-api  Apache 2.0
-   proto files from opencensus: https://github.com/census-instrumentation/opencensus-proto/tree/master/gen-go  Apache 2.0
-   proto files from prometheus/client_model: https://github.com/prometheus/client_model Apache 2.0
-   proto files from opentelemetry: https://github.com/open-telemetry/opentelemetry-proto/tree/main/opentelemetry/proto Apache 2.0
-   proto files from opentelemetry: https://github.com/open-telemetry/opentelemetry-proto/tree/v0.7.0 Apache 2.0
-   flatbuffers files from istio/proxy: https://github.com/istio/proxy Apache 2.0
-   mvnw files from https://github.com/apache/maven-wrapper Apache 2.0
-   svg files from skywalking-ui/src/assets/icons: https://github.com/google/material-design-icons Apache 2.0
-   ZipkinQueryHandler.java reference from zipkin2.server.internal.ZipkinQueryApiV2: https://github.com/openzipkin/zipkin  Apache 2.0

--- a/NOTICE
+++ b/NOTICE
@@ -3,24 +3,3 @@ Copyright 2017-2023 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
-
------------------------------------------------------------------------
-This product contains code from the Prometheus Project:
-
-Data model artifacts for Prometheus.
-Copyright 2012-2015 The Prometheus Authors
-
-This product includes software developed at
-SoundCloud Ltd. (http://soundcloud.com/).
------------------------------------------------------------------------
-This product contains code from the Apache Maven Wrapper Project:
-
-Apache Maven Wrapper
-Copyright 2013-2022 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).
-
-The original idea and initial implementation of the maven-wrapper module is derived 
-from the Gradle Wrapper which was written originally by Hans Dockter and Adam Murdoch.
-Copyright 2007 the original author or authors.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# SkyWalking Terraform and Ansible
+
+This repository contains the Terraform scripts to create the infrastructure for SkyWalking on cloud vendors,
+and the Ansible playbooks to install SkyWalking on the created infrastructure, or on the existing infrastructure,
+no matter on-premises or on cloud vendors, such as AWS.
+
+# Terraform
+
+For now, we have supported the following cloud vendors, and we welcome everyone to contribute supports for
+more cloud vendors:
+
+- Amazon Web Services (AWS): go to the [aws](aws) folder for more details.
+
+# Ansible
+
+You can use the Ansible playbook in combination with the Terraform to create necessary infrastructure and install
+SkyWalking on the created infrastructure, or you can use the Ansible to install SkyWalking on the existing infrastructure.
+The Ansible playbook and documentation about how to use it can be found in the [ansible](ansible) folder.


### PR DESCRIPTION
@rabajaj0509 I have shaped the doc in this PR and we'd be better to fill in the doc when we gradually polish the codebase, let's add docs about features, available options, so that we won't miss doc for any feature.

I'm not sure whether terraform can generate a markdown table for the variables that we defined in the terraform modules, that would save us a lot of time