### PR TITLE
Allow communication from SkyWalking UI to OAP on port 12800

### DIFF
--- a/aws/ec2.tf
+++ b/aws/ec2.tf
@@ -31,7 +31,8 @@ resource "aws_instance" "skywalking-oap" {
   key_name = aws_key_pair.ssh-user.id
   vpc_security_group_ids = [
     aws_security_group.ssh-access.id,
-    aws_security_group.public-egress-access.id
+    aws_security_group.public-egress-access.id,
+    aws_security_group.ui-to-oap-communication.id
   ]
 }
 
@@ -88,6 +89,18 @@ resource "aws_security_group" "public-egress-access" {
       self            = false
     }
   ]
+  tags = var.extra_tags
+}
+
+resource "aws_security_group" "ui-to-oap-communication" {
+  name        = "ui-to-oap-communication"
+  description = "Allow communication from SkyWalking UI to SkyWalking OAP"
+  ingress {
+    from_port      = 0
+    to_port        = 12800
+    protocol       = "tcp"
+    security_groups = [aws_security_group.public-egress-access.id]
+  }
   tags = var.extra_tags
 }
 

--- a/aws/ec2.tf
+++ b/aws/ec2.tf
@@ -99,6 +99,7 @@ resource "aws_security_group" "ui-to-oap-communication" {
     from_port      = 0
     to_port        = 12800
     protocol       = "tcp"
+    cidr_blocks    = ["0.0.0.0/0"]
     security_groups = [aws_security_group.public-egress-access.id]
   }
   tags = var.extra_tags


### PR DESCRIPTION
This commit adds a security group rule to allow communication from the SkyWalking UI instances to the SkyWalking OAP instances on port 12800. The rule is configured to accept incoming traffic from any source port on the SkyWalking UI instances, directing it to port 12800 on the SkyWalking OAP instances.