### PR TITLE
Polish the Terraform script and Ansible playbook

### DIFF
--- a/ansible/roles/skywalking/tasks/main.yml
+++ b/ansible/roles/skywalking/tasks/main.yml
@@ -23,24 +23,28 @@
     group: skywalking
     mode: "0755"
 
-- name: Download Apache SkyWalking tar file
+- name: Download Apache SkyWalking tarball
+  when: skywalking_tarball is match('^https?://.*')
   get_url:
-    url: "https://dlcdn.apache.org/skywalking/{{ skywalking_version }}/apache-skywalking-apm-{{ skywalking_version }}.tar.gz"
-    dest: "/usr/local/skywalking/apache-skywalking-apm-{{ skywalking_version }}.tar.gz"
+    url: "{{ skywalking_tarball }}"
+    timeout: 120
+    dest: /usr/local/skywalking/apache-skywalking-apm.tar.gz
+
+- name: Upload Local Apache SkyWalking tarball
+  when: skywalking_tarball is not match('^https?://.*')
+  ansible.builtin.copy:
+    src: "{{ skywalking_tarball }}"
+    dest: /usr/local/skywalking/apache-skywalking-apm.tar.gz
+    owner: skywalking
+    group: skywalking
+    mode: '0755'
 
 - name: Extract tar file
   unarchive:
-    src: "/usr/local/skywalking/apache-skywalking-apm-{{ skywalking_version }}.tar.gz"
+    src: /usr/local/skywalking/apache-skywalking-apm.tar.gz
     dest: "/usr/local/skywalking"
     remote_src: yes
     extra_opts: [--strip-components=1]
-
-- name: Set ownership for extracted files
-  ansible.builtin.file:
-    path: /usr/local/skywalking
-    owner: skywalking
-    group: skywalking
-    recurse: yes
 
 - name: Check hostgroup size
   set_fact:

--- a/ansible/roles/skywalking/vars/main.yml
+++ b/ansible/roles/skywalking/vars/main.yml
@@ -14,7 +14,11 @@
 # limitations under the License.
 
 ---
-skywalking_version: "9.5.0"
+# skywalking_tarball can be a remote URL or a local path, if it's a remote URL
+# the remote file will be downloaded to the remote host and then extracted,
+# if it's a local path, the local file will be copied to the remote host and
+# then extracted.
+skywalking_tarball: "https://dist.apache.org/repos/dist/release/skywalking/9.5.0/apache-skywalking-apm-9.5.0.tar.gz"
 sw_ui_server_port: "8080"
 sw_oap_server_port: "12800"
 sw_zipkin_address: "9412"

--- a/aws/ec2.tf
+++ b/aws/ec2.tf
@@ -14,16 +14,18 @@
 # limitations under the License.
 
 provider "aws" {
-    region = var.region
+  region     = var.region
+  access_key = var.access_key
+  secret_key = var.secret_key
 }
 
 resource "aws_instance" "skywalking-oap" {
-  count = var.oap_instance_count
-  ami = data.aws_ami.amazon-linux.id
+  count         = var.oap_instance_count
+  ami           = data.aws_ami.amazon-linux.id
   instance_type = var.instance_type
   tags = merge(
     {
-      Name = "skywalking-oap"
+      Name        = "skywalking-oap"
       Description = "Installing and configuring SkyWalking OAPService on AWS"
     },
     var.extra_tags
@@ -37,12 +39,12 @@ resource "aws_instance" "skywalking-oap" {
 }
 
 resource "aws_instance" "skywalking-ui" {
-  count = var.ui_instance_count
-  ami = data.aws_ami.amazon-linux.id
+  count         = var.ui_instance_count
+  ami           = data.aws_ami.amazon-linux.id
   instance_type = var.instance_type
   tags = merge(
     {
-      Name = "skywalking-ui"
+      Name        = "skywalking-ui"
       Description = "Installing and configuring SkyWalking UI on AWS"
     },
     var.extra_tags
@@ -55,38 +57,38 @@ resource "aws_instance" "skywalking-ui" {
 }
 
 resource "aws_security_group" "ssh-access" {
-  name = "ssh-access"
+  name        = "ssh-access"
   description = "Allow SSH access from the Internet"
   ingress = [
     {
-      from_port = 22
-      to_port = 22
-      protocol = "tcp"
-      cidr_blocks = ["0.0.0.0/0"]
-      description     = "SSH access rule"
+      from_port        = 22
+      to_port          = 22
+      protocol         = "tcp"
+      cidr_blocks      = ["0.0.0.0/0"]
+      description      = "SSH access rule"
       ipv6_cidr_blocks = []
-      prefix_list_ids = []
-      security_groups = []
-      self            = false
+      prefix_list_ids  = []
+      security_groups  = []
+      self             = false
     }
   ]
   tags = var.extra_tags
 }
 
 resource "aws_security_group" "public-egress-access" {
-  name = "public-egress-access"
+  name        = "public-egress-access"
   description = "Allow access to the Internet"
   egress = [
     {
-      from_port = 0
-      to_port = 0
-      protocol = -1
-      cidr_blocks = ["0.0.0.0/0"]
-      description     = "Allow access to the Internet"
+      from_port        = 0
+      to_port          = 0
+      protocol         = -1
+      cidr_blocks      = ["0.0.0.0/0"]
+      description      = "Allow access to the Internet"
       ipv6_cidr_blocks = []
-      prefix_list_ids = []
-      security_groups = []
-      self            = false
+      prefix_list_ids  = []
+      security_groups  = []
+      self             = false
     }
   ]
   tags = var.extra_tags
@@ -96,10 +98,10 @@ resource "aws_security_group" "ui-to-oap-communication" {
   name        = "ui-to-oap-communication"
   description = "Allow communication from SkyWalking UI to SkyWalking OAP"
   ingress {
-    from_port      = 0
-    to_port        = 12800
-    protocol       = "tcp"
-    cidr_blocks    = ["0.0.0.0/0"]
+    from_port       = 0
+    to_port         = 12800
+    protocol        = "tcp"
+    cidr_blocks     = ["0.0.0.0/0"]
     security_groups = [aws_security_group.public-egress-access.id]
   }
   tags = var.extra_tags
@@ -110,9 +112,9 @@ resource "local_file" "oap_instance_ips" {
   content = join("\n", flatten([
     ["[skywalking_oap]"],
     aws_instance.skywalking-oap.*.public_ip,
-    [""]  # Adds an empty string for the trailing newline
+    [""] # Adds an empty string for the trailing newline
   ]))
-  filename = "${path.module}/../ansible/inventory/oap-server"
+  filename        = "${path.module}/../ansible/inventory/oap-server"
   file_permission = "0600"
 }
 
@@ -121,8 +123,8 @@ resource "local_file" "ui_instance_ips" {
   content = join("\n", flatten([
     ["[skywalking_ui]"],
     aws_instance.skywalking-ui.*.public_ip,
-    [""]  # Adds an empty string for the trailing newline
+    [""] # Adds an empty string for the trailing newline
   ]))
-  filename = "${path.module}/../ansible/inventory/ui-server"
+  filename        = "${path.module}/../ansible/inventory/ui-server"
   file_permission = "0600"
 }

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -29,6 +29,18 @@ variable "region" {
   default     = "us-east-1"
 }
 
+variable "access_key" {
+  type        = string
+  description = "Access key of the AWS account"
+  default     = ""
+}
+
+variable "secret_key" {
+  type        = string
+  description = "Secret key of the AWS account"
+  default     = ""
+}
+
 variable "instance_type" {
   type        = string
   description = "CPU, memory, storage and networking capacity"


### PR DESCRIPTION
- Allow using both remote SkyWalking binary package or locally built package.
- Add AWS `access_key` and `secret_key` to Terraform variables so users do not need to configure the AWS credentials locally for this repo instead of globally.